### PR TITLE
replace _genUrl() with API path from docs

### DIFF
--- a/src/main/rdplugin/assets/js/jobgraph.js
+++ b/src/main/rdplugin/assets/js/jobgraph.js
@@ -417,7 +417,7 @@ jQuery(function () {
 
     self.load = function (id) {
       return jQuery.ajax({
-        url: "/api/34/job/" + id + "/workflow",
+        url: "/api/" + appLinks.api_version + "/job/" + id + "/workflow",
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }
@@ -425,13 +425,12 @@ jQuery(function () {
     };
     self.find = function (group, name) {
       return jQuery.ajax({
-        url: "/api/34/" + project + "/jobs?jobExactFilter=" + name + "&groupPathExact=" + group,
+        url: "/api/" + appLinks.api_version + "/" + project + "/jobs?jobExactFilter=" + name + "&groupPathExact=" + group,
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }
       });
     };
-
 
   }
 

--- a/src/main/rdplugin/assets/js/jobgraph.js
+++ b/src/main/rdplugin/assets/js/jobgraph.js
@@ -308,6 +308,7 @@ jQuery(function () {
 
   function JobDataLoader() {
     var self = this;
+    var apiBase = window._rundeck.rdBase + '/api/' + window._rundeck.apiVersion;
     self.jobdata = {};
     self.undefjobs = {};
     self.undef = 0;
@@ -417,7 +418,7 @@ jQuery(function () {
 
     self.load = function (id) {
       return jQuery.ajax({
-        url: "/api/" + appLinks.api_version + "/job/" + id + "/workflow",
+        url: apiBase + "/job/" + id + "/workflow",
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }
@@ -425,7 +426,7 @@ jQuery(function () {
     };
     self.find = function (group, name) {
       return jQuery.ajax({
-        url: "/api/" + appLinks.api_version + "/" + project + "/jobs?jobExactFilter=" + name + "&groupPathExact=" + group,
+        url: apiBase + "/" + project + "/jobs?jobExactFilter=" + name + "&groupPathExact=" + group,
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }

--- a/src/main/rdplugin/assets/js/jobgraph.js
+++ b/src/main/rdplugin/assets/js/jobgraph.js
@@ -417,9 +417,7 @@ jQuery(function () {
 
     self.load = function (id) {
       return jQuery.ajax({
-        url: _genUrl(appLinks.scheduledExecutionWorkflowJson, {
-          id: id
-        }),
+        url: "/api/34/job/" + id + "/workflow",
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }
@@ -427,11 +425,7 @@ jQuery(function () {
     };
     self.find = function (group, name) {
       return jQuery.ajax({
-        url: _genUrl(appLinks.menuJobsAjax, {
-          project: project,
-          jobExactFilter: name,
-          groupPathExact: group
-        }),
+        url: "/api/34/" + project + "/jobs?jobExactFilter=" + name + "&groupPathExact=" + group,
         method: 'GET',
         contentType: 'json'
         // success:function(data){ }


### PR DESCRIPTION
When this was pulled out of the rundeck code base it retained links to the grails app. This patch replaces the calls to _genUrl() with strings extracted from the API documentation