### PR TITLE
replace .success() with .done() due to JS deprecation. Fixes UI dash load error.

### DIFF
--- a/src/main/rdplugin/assets/js/jobgraph.js
+++ b/src/main/rdplugin/assets/js/jobgraph.js
@@ -482,7 +482,7 @@ jQuery(function () {
             if (data && data.length == 1) {
               var jobobj = data[0];
               var jid = jobobj.id;
-              loader.load(jid).success(function (data2) {
+              loader.load(jid).done(function (data2) {
                 var count = loader.loadJobData(jid, jobgroup, jobname, data2, joblist);
                 loadNextJob(final)
               });
@@ -490,7 +490,7 @@ jQuery(function () {
           });
         }
       } else if (loader.jobdata[jobid] == null) {
-        loader.load(jobid).success(function (data) {
+        loader.load(jobid).done(function (data) {
           var count = loader.loadJobData(jobid, jobgroup, jobname, data, joblist);
           loadNextJob(final)
         });


### PR DESCRIPTION
Apologies for the duplicate PR. This seems to fix a dashboard load error that prevents the javascript from running properly. Without it, I receive this in the console:

Uncaught TypeError: loader.load(...).success is not a function
    loadNextJob https://rundeck.testsite.com/plugin/file/UI/ui-job-graph/js/jobgraph.js:755
    loadJobListData https://rundeck.testsite.com/plugin/file/UI/ui-job-graph/js/jobgraph.js:763
    loadJobsListPage https://rundeck.testsite.com/plugin/file/UI/ui-job-graph/js/jobgraph.js:459

To fix this, the method has to be changed as below, because there is .success() in these locations. Can someone please verify if this fix works?